### PR TITLE
fix(security): limit GitHub Actions workflow permissions

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: ["3.10"]


### PR DESCRIPTION
Adds explicit read-only permissions to the build job in python-publish.yml to follow least privilege principle and address GitHub security alert.