### PR TITLE
fix(gen): Gracefully handle missing ruff during code generation

### DIFF
--- a/supabase_pydantic/cli.py
+++ b/supabase_pydantic/cli.py
@@ -14,6 +14,7 @@ from supabase_pydantic.util import (
     AppConfig,
     DatabaseConnectionType,
     FileWriterFactory,
+    RuffNotFoundError,
     ToolConfig,
     WriterConfig,
     clean_directories,
@@ -333,13 +334,15 @@ def gen(
             logging.info(f"{job} models generated successfully for schema '{s}': {p}")
 
     # Format the generated files
-    try:
-        for p in paths:
+    # Format the generated files
+    for p in paths:
+        try:
             format_with_ruff(p)
             logging.info(f'File formatted successfully: {p}')
-    except Exception as e:
-        logging.error('An error occurred while running ruff:')
-        logging.error(str(e))
+        except RuffNotFoundError as e:
+            logging.warning(str(e))  # The exception message is already descriptive
+        except Exception as e:  # Catch any other unexpected errors during formatting
+            logging.error(f'An unexpected error occurred while formatting {p}: {str(e)}')
 
     # Generate seed data
     if create_seed_data:

--- a/supabase_pydantic/util/__init__.py
+++ b/supabase_pydantic/util/__init__.py
@@ -15,6 +15,7 @@ from .constants import (
 )
 from .dataclasses import AsDictParent, ColumnInfo, ForeignKeyInfo, TableInfo
 from .db import check_connection, construct_tables, create_connection, query_database
+from .exceptions import RuffNotFoundError
 from .fake import generate_fake_data
 from .json import CustomJsonEncoder
 from .sorting import (
@@ -75,4 +76,5 @@ __all__ = [
     'to_pascal_case',
     'topological_sort',
     'write_seed_file',
+    'RuffNotFoundError',
 ]

--- a/supabase_pydantic/util/exceptions.py
+++ b/supabase_pydantic/util/exceptions.py
@@ -2,3 +2,12 @@ class ConnectionError(Exception):
     """Raised when a connection to the Supabase API cannot be established."""
 
     pass
+
+
+class RuffNotFoundError(Exception):
+    """Custom exception raised when the ruff executable is not found."""
+
+    def __init__(self, file_path: str, message: str = 'Ruff executable not found. Formatting skipped.'):
+        self.file_path = file_path
+        self.message = f'{message} For file: {file_path}'
+        super().__init__(self.message)

--- a/supabase_pydantic/util/sorting.py
+++ b/supabase_pydantic/util/sorting.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from supabase_pydantic.util.constants import RelationType
 from supabase_pydantic.util.dataclasses import ColumnInfo, RelationshipInfo, TableInfo
+from supabase_pydantic.util.exceptions import RuffNotFoundError
 from supabase_pydantic.util.fake import format_for_postgres, generate_fake_data, guess_datetime_order
 
 pp = pprint.PrettyPrinter(indent=4)
@@ -34,9 +35,7 @@ def format_with_ruff(file_path: str) -> None:
         print(e.stderr)
         print('The file was generated, but not formatted.')
     except FileNotFoundError:
-        print(f'WARNING: `ruff` command not found. Skipping formatting for {file_path}.')
-        print('To enable auto-formatting, please install ruff in your environment')
-        print('(e.g., `pip install ruff` or add it to your project dependencies).')
+        raise RuffNotFoundError(file_path=file_path)
 
 
 def build_dependency_graph(tables: list[TableInfo]) -> tuple[defaultdict[str, list[str]], dict[str, int]]:

--- a/supabase_pydantic/util/sorting.py
+++ b/supabase_pydantic/util/sorting.py
@@ -30,8 +30,13 @@ def format_with_ruff(file_path: str) -> None:
         # Finally run ruff check --fix for any remaining issues
         _ = subprocess.run(['ruff', 'check', '--fix', file_path], check=True, text=True, capture_output=True)
     except subprocess.CalledProcessError as e:
-        print('Error during Ruff processing:')
-        print(e.stderr)  # Print any error output from ruff
+        print(f'WARNING: An error occurred while trying to format {file_path} with ruff:')
+        print(e.stderr)
+        print('The file was generated, but not formatted.')
+    except FileNotFoundError:
+        print(f'WARNING: `ruff` command not found. Skipping formatting for {file_path}.')
+        print('To enable auto-formatting, please install ruff in your environment')
+        print('(e.g., `pip install ruff` or add it to your project dependencies).')
 
 
 def build_dependency_graph(tables: list[TableInfo]) -> tuple[defaultdict[str, list[str]], dict[str, int]]:


### PR DESCRIPTION
The formatting utility now catches `FileNotFoundError` if the
ruff executable is not found in the environment. Instead of crashing,
it prints a warning and skips the formatting step.

This allows the `sb-pydantic gen` command to complete successfully
even when ruff (a dev dependency) is not installed, improving
robustness for users who install supabase-pydantic as a library.