### PR TITLE
Added support for getting column description from postgres and mysql

### DIFF
--- a/src/supabase_pydantic/core/writers/pydantic.py
+++ b/src/supabase_pydantic/core/writers/pydantic.py
@@ -211,6 +211,8 @@ class PydanticFastAPIClassWriter(AbstractClassWriter):
             field_values['default'] = 'None'
         if c.alias is not None:
             field_values['alias'] = f'"{c.alias}"'
+        if c.description is not None:
+            field_values['description'] = f'"{c.description}"'
 
         # Construct the final column definition
         col = f'{c.name}: {type_str}'

--- a/src/supabase_pydantic/db/drivers/mysql/queries.py
+++ b/src/supabase_pydantic/db/drivers/mysql/queries.py
@@ -65,7 +65,8 @@ SELECT
         ELSE NULL
     END as identity_generation,
     c.data_type as udt_name,
-    NULL as array_element_type
+    NULL as array_element_type,
+    c.column_comment as description
 FROM
     information_schema.columns AS c
 JOIN

--- a/src/supabase_pydantic/db/drivers/postgres/queries.py
+++ b/src/supabase_pydantic/db/drivers/postgres/queries.py
@@ -55,13 +55,20 @@ SELECT
     CASE
         WHEN c.data_type = 'ARRAY' THEN pg_catalog.format_type(e.oid, NULL)
         ELSE NULL
-    END as array_element_type
+    END AS array_element_type,
+    pgd.description
 FROM
     information_schema.columns AS c
 JOIN
     information_schema.tables AS t ON c.table_name = t.table_name AND c.table_schema = t.table_schema
 LEFT JOIN pg_type e
     ON e.typname = c.udt_name
+LEFT JOIN pg_catalog.pg_class cls
+    ON cls.relname = c.table_name
+   AND cls.relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = c.table_schema)
+LEFT JOIN pg_catalog.pg_description pgd
+    ON pgd.objoid = cls.oid
+   AND pgd.objsubid = c.ordinal_position
 WHERE
     c.table_schema = %s
     AND (t.table_type = 'BASE TABLE' OR t.table_type = 'VIEW')

--- a/src/supabase_pydantic/db/marshalers/schema.py
+++ b/src/supabase_pydantic/db/marshalers/schema.py
@@ -46,6 +46,7 @@ def get_table_details_from_columns(
             identity_generation,
             udt_name,
             array_element_type,
+            description,
         ) = row
         table_key: tuple[str, str] = (schema, table_name)
         if table_key not in tables:
@@ -67,6 +68,7 @@ def get_table_details_from_columns(
             max_length=max_length,
             is_identity=identity_generation is not None,
             array_element_type=array_element_type,
+            description=description,
         )
         tables[table_key].add_column(column_info)
 

--- a/src/supabase_pydantic/db/models.py
+++ b/src/supabase_pydantic/db/models.py
@@ -90,6 +90,7 @@ class ColumnInfo(AsDictParent):
     is_identity: bool = False  # For auto-generated identity columns
     enum_info: EnumInfo | None = None  # New field for enum metadata
     array_element_type: str | None = None  # Stores element type for array columns
+    description: str | None = None # Stores the description of the column
 
     def __str__(self) -> str:
         """Return a string representation of the column."""


### PR DESCRIPTION
## Problem

Supabase allows the option to add descriptions to columns. These descriptions are very useful for agentic applications, as they provide context of what is the meaning of each colum.

Providing context to agentic applications can be achieved with pydactic Field description. However, directly modifying the generated pydactic can be error prone, and make it hard to keep a centralized description among different applications in different languages.

## Goal

The goal of this pull request is to use supabase as the central point to store column descriptions and then use generators as `supabase-pydantic` to generate Fields wth descriptions.

## Supabase Description

To set a description for a column under a supabase project click on:

Table Editor > [your table] > [your column] > Edit column > Description